### PR TITLE
fix(usehistorytravel): 先forward或back再修改current时，第一次的修改没有进入past数组中

### DIFF
--- a/__test__/useHistoryTravel.spec.ts
+++ b/__test__/useHistoryTravel.spec.ts
@@ -18,7 +18,7 @@ describe('test history travel', () => {
       backLength,
       forwardLength,
       back,
-      forward,
+      forward
     } = useHistoryTravel(1)
     expect(isRef(current)).toBeTruthy()
     expect(current.value).toBe(1)
@@ -57,5 +57,14 @@ describe('test history travel', () => {
     expect(current.value).toBe(4)
     expect(backLength.value).toBe(3)
     expect(forwardLength.value).toBe(0)
+  })
+
+  test('fix: the first, forward or go, the next, change current but not record to history', () => {
+    const { current, forward, backLength } = useHistoryTravel(7)
+    forward()
+    current.value = 77
+    expect(backLength.value).toBe(1)
+    current.value = 99
+    expect(backLength.value).toBe(2)
   })
 })

--- a/src/useHistoryTravel/index.ts
+++ b/src/useHistoryTravel/index.ts
@@ -82,7 +82,10 @@ export function useHistoryTravel<T>(initialValue?: T): ReturnValue<T> {
   }
 
   function _back(step = -1) {
-    if (travelState.past.length <= 0) return
+    if (travelState.past.length <= 0) {
+      updateFrom = UpdateStateFrom.USER
+      return
+    }
     const { _after, _current, _before } = split(step, travelState.past)
     updatePast(_before, true)
     updateFuture([..._after, current.value])
@@ -90,7 +93,10 @@ export function useHistoryTravel<T>(initialValue?: T): ReturnValue<T> {
   }
 
   function _forward(step = 1) {
-    if (travelState.future.length <= 0) return
+    if (travelState.future.length <= 0) {
+      updateFrom = UpdateStateFrom.USER
+      return
+    }
     const { _after, _current, _before } = split(step, travelState.future)
     updatePast([current.value, ..._before])
     updateFuture(_after, true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,18 +450,10 @@
     "@babel/helper-create-class-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-proposal-class-properties@^7.12.1":
+"@babel/plugin-proposal-class-properties@^7.12.1", "@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
   integrity sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.12.1"
-    "@babel/helper-plugin-utils" "^7.10.4"
-
-"@babel/plugin-proposal-class-properties@^7.8.3":
-  version "7.12.1"
-  resolved "https://npm.c2cloud.cn/@babel/plugin-proposal-class-properties/download/@babel/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
-  integrity sha1-oIL/VB8qKaSCEGW4rdk0bAwW5d4=
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"


### PR DESCRIPTION
修复usehistorytravel函数bug，当先执行forward或者back函数，再修改current，第一次修改后的值没有记录到past数组中